### PR TITLE
Add env-file option for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# Use Python 3.11 slim image
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy requirements and install
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Expose port
+EXPOSE 8000
+
+# Command to run the API
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -53,6 +53,21 @@ OPENAI_API_KEY=your_api_key_here
 python storyGenerator.py --theme "Space Adventure"
 ```
 
+## 🐳 Docker
+
+You can also run the API using Docker:
+
+```bash
+# Build the image
+docker build -t storybook-api .
+
+# Run the container (exposes port 8000)
+docker run -p 8000:8000 -e OPENAI_API_KEY=your_api_key_here storybook-api
+
+# O bien carga la clave desde un archivo `.env`
+docker run --env-file .env -p 8000:8000 storybook-api
+```
+
 ## 📖 Usage
 
 ```python

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,10 +6,14 @@ beautifulsoup4
 pdfkit
 requests
 xhtml2pdf
-beautifulsoup4
 reportlab
 python-dotenv
 fastapi
 uvicorn
 pytest
-httpx
+httpx<0.28
+openai
+crewai
+crewai-tools
+langchain-openai
+markdown-pdf


### PR DESCRIPTION
## Summary
- update README's Docker instructions with `--env-file` example

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846baf1df74832ca55cce87ff31df3d